### PR TITLE
Fix: Replace License with the valid GPLv3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         # http://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU GENERAL PUBLIC LICENSE',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Operating System :: Unix',
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',


### PR DESCRIPTION
I just replaced the "License" line. Based on the "LICENSE" file in the project, I chose the GPLv3.

I did not try to publish to not "pollute" your namespace, but If you want, I could try to deploy with another name.

Fixes issue #50
This refers to the issue #31
and the pull request #47